### PR TITLE
Alterações

### DIFF
--- a/src/functions.py
+++ b/src/functions.py
@@ -37,12 +37,15 @@ def try_connect( port_num , host_ip , timeout = 1. ):
 
 def string_connect_result( port_num , result, dt ):
     
-    port_name = sck.getservbyport( port_num ).upper()
+    try:
+        port_name = sck.getservbyport( port_num ).upper()
+    except OSError:
+        port_name = "NO SERVICE"
     true_time = "{:.5f} seconds".format( dt )
     
 
     s = "-"*50 + "\n"
-    s += "{} {}\n".format( port_num , port_name )
+    s += "PORT {}: {}\n".format( port_num , port_name )
     s += result + "\n"
     s += true_time
 
@@ -84,12 +87,6 @@ def iteractive_scan( host_name, start , end , timeout = 1. , alpha = .15 ):
     summary = {}
 
     for port_num in range( start , end + 1 ):
-        
-        #--------------------------------------------------
-        # algus valores para porta não tem um protocolo mapeado
-        # se for o caso pula-se o numero
-        try: sck.getservbyport( port_num )
-        except OSError: continue
 
         result , dt = try_connect( port_num, host_ip, timeout )
         s = string_connect_result( port_num, result, dt )

--- a/src/functions.py
+++ b/src/functions.py
@@ -69,7 +69,7 @@ def summary_str( summary ):
     return s
 
 
-def iteractive_scan( host_name, start , end , timeout = 1.):
+def iteractive_scan( host_name, start , end , timeout):
     
     '''
     escaneameto de modo iterativo, em contraste com o modo multithread
@@ -115,10 +115,9 @@ def handle_input( input_lst ):
     if len( input_lst ) > 2:
         end = min( 65535 , int( input_lst[ 2 ] ) )
 
-    timeout = 1.
+    timeout = 22.
     if len( input_lst ) > 3:
-        timeout = max( 1. , float( input_lst[ 3 ] ) )
-        timeout = min( 60. , timeout )
+        timeout = max( 3. , float( input_lst[ 3 ] ) )
     
     return host_name , start , end , timeout
 
@@ -138,7 +137,7 @@ if __name__ == "__main__":
     #     print( "\n ABORTANDO!" )
     #     sys.exit()
 
-    s , start , end , t , a = handle_input( sys.argv[ 1: ] )
+    s , start , end , t = handle_input( sys.argv[ 1: ] )
     resp = iteractive_scan( s , start, end, timeout = t)
     try:
         for s in resp:

--- a/src/functions.py
+++ b/src/functions.py
@@ -23,15 +23,14 @@ def try_connect( port_num , host_ip , timeout = 1. ):
     try: sock.connect( tup )
     except sck.error as e:
         result = "FECHADA"
-        if e.__class__ == sck.timeout or e.args[0] == 10060:
+        if e.__class__ == sck.timeout or e.__class__ == TimeoutError:
             result = "FILTRADA"
+    else:
+        # ja tem-se o errno então não precisamos mais do so
+        # cket.
+        sock.shutdown( sck.SHUT_RDWR )
     dt = time.time() - t
 
-    #--------------------------------------------------
-    # ja tem-se o errno então não precisamos mais do so
-    # cket.
-    if result != "FECHADA":
-        sock.shutdown( sck.SHUT_RDWR )
     sock.close()
 
     return result , dt

--- a/src/functions.py
+++ b/src/functions.py
@@ -51,13 +51,12 @@ def string_connect_result( port_num , result, dt ):
 
     return s
 
-def scan_header( host_name, start , end , timeout = 1. , alpha = .15 ):
+def scan_header( host_name, start , end , timeout = 1.):
 
     host_ip = sck.gethostbyname( host_name )
     s = "\nHost \"{}\" have IP of \"{}\"\n".format( host_name , host_ip )
     s += "START {} END {}\n".format( start , end )
     s += "TIMEOUT OF {:.5F} seconds\n".format( timeout )
-    s += "ALPHA OF {:.5f}%\n".format( 100*alpha )
 
     return s
 
@@ -70,13 +69,13 @@ def summary_str( summary ):
     return s
 
 
-def iteractive_scan( host_name, start , end , timeout = 1. , alpha = .15 ):
+def iteractive_scan( host_name, start , end , timeout = 1.):
     
     '''
     escaneameto de modo iterativo, em contraste com o modo multithread
     '''
 
-    s = scan_header( host_name, start , end , timeout , alpha )
+    s = scan_header( host_name, start , end , timeout)
     yield s
     
     host_ip = sck.gethostbyname( host_name )
@@ -91,10 +90,6 @@ def iteractive_scan( host_name, start , end , timeout = 1. , alpha = .15 ):
         result , dt = try_connect( port_num, host_ip, timeout )
         s = string_connect_result( port_num, result, dt )
         yield s
-
-        #--------------------------------------------------
-        # recomputando timeout
-        timeout = ( 1 - alpha )*timeout + alpha*dt
 
         #--------------------------------------------------
         # salvando resultados na para summrizar
@@ -124,14 +119,8 @@ def handle_input( input_lst ):
     if len( input_lst ) > 3:
         timeout = max( 1. , float( input_lst[ 3 ] ) )
         timeout = min( 60. , timeout )
-
-    alpha = .1
-    if len( input_lst ) > 4:
-        alpha = max( 1 , int( input_lst[ 4 ] ) )
-        alpha = min( 100 , alpha )
-        alpha /= 100
     
-    return host_name , start , end , timeout, alpha
+    return host_name , start , end , timeout
 
 if __name__ == "__main__":
     
@@ -150,7 +139,7 @@ if __name__ == "__main__":
     #     sys.exit()
 
     s , start , end , t , a = handle_input( sys.argv[ 1: ] )
-    resp = iteractive_scan( s , start, end, timeout = t, alpha = a )
+    resp = iteractive_scan( s , start, end, timeout = t)
     try:
         for s in resp:
             print( s )

--- a/src/functions.py
+++ b/src/functions.py
@@ -51,7 +51,7 @@ def string_connect_result( port_num , result, dt ):
 def scan_header( host_name, start , end , timeout = 1. , alpha = .15 ):
 
     host_ip = sck.gethostbyname( host_name )
-    s = "\nHost with name \"{}\" have IP of \"{}\"\n".format( host_name , host_ip )
+    s = "\nHost \"{}\" have IP of \"{}\"\n".format( host_name , host_ip )
     s += "START {} END {}\n".format( start , end )
     s += "TIMEOUT OF {:.5F} seconds\n".format( timeout )
     s += "ALPHA OF {:.5f}%\n".format( 100*alpha )


### PR DESCRIPTION
shutdown:
def try_connect() / linha 28
Estava dando erro ao fazer o shutdown após uma porta filtrada. Desta forma, o shutdown só ocorre após uma conexão sem erro (porta aberta)
def try_connect / linha 26
Mudei um pouco o tratamento de erros para porta filtrada (acho q o jeito q eu tinha feito antes poderia dar errado)

host_name:
def scan_header() / linha 57
Mudei um pouco a mensagem do header, pois pelas especificações do trabalho, a entrada pode ser um nome de host ou o IP

portas puladas:
def string_connect_result() / linha 40
Pelo q eu entendi das especificações do trabalho, as portas sem protocolo mapeado também devem ser analisadas (classifiquei as sem protocolo como "NO SERVICE")
def string_connect_result() / linha 48
Acrescentei PORT no início da mensagem de cada porta

alpha:
Tirei alpha e a recomputação do timeout. Como o resultado das portas abertas é recebido muito rápido, uma porta aberta poderia abaixar muito o timeout (mesmo com um alpha baixo) e alterar a definição das outras portas. E, mesmo se o tempo das portas abertas for desconsiderado, como o tempo atual do timeout é o máximo a ser alcançado, a recomputação sempre gerará um valor menor ou igual ao anterior até, possivelmente (principalmente em intervalo de portas muito grandes), chegar em um valor mais baixo q o tempo de resposta de uma porta fechada (normalmente entre 2-3 segundos), fazendo elas serem consideradas filtradas. Por isso, achei melhor deixar o tempo do timeout fixo

timeout:
def handle_input() / linha 118
Alterei o valor mínimo do timeout para 3 (normalmente é o necessário para não interferir na classificação de portas fechadas), e coloquei o padrão para 22 (acima do valor do timeout do sistema). Acho melhor deixar o timeout padrão sem chances de classificar portas de forma errada e no README explicar isto para o professor e recomendar 3 segundos de timeout para aumentar a eficiência